### PR TITLE
fix: Always take the closest path for spherical linear interpolation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minterpolate"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 repository = "https://github.com/rustgd/minterpolate.git"
 homepage = "https://github.com/rustgd/minterpolate"

--- a/src/spherical_linear.rs
+++ b/src/spherical_linear.rs
@@ -37,9 +37,13 @@ where
     } else {
         let d = (input - inputs[input_index]) / (inputs[input_index + 1] - inputs[input_index]);
         let left = outputs[input_index];
-        let right = outputs[input_index + 1];
+        let mut right = outputs[input_index + 1];
 
-        let dot = left.dot(&right);
+        let mut dot = left.dot(&right);
+        if dot < 0. {
+            dot = -dot;
+            right = right.mul(-1.);
+        }
         let dot_threshold = cast(0.9995f32).unwrap();
         let v = if dot > dot_threshold {
             left.add(&right.sub(&left).mul(d))


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/minterpolate/8)
<!-- Reviewable:end -->
